### PR TITLE
set-name-in-japanese

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import Main from './Main';
 import SignIn from './SignIn';
 
 
@@ -7,6 +8,13 @@ export default () => {
   //useStateを使う。初期値を空文字「('')」とする。状態の名前を「name」とする。
   const [name, setName] = useState('');
   console.log({name});
+  //nameが空だった場合はSignInを返す
+  if (name === '') {
+    return <SignIn setName={setName} />;
+  } else {
+    //nameが空じゃない場合はMainコンポーネントのnameを返す。
+    return <Main name={name} />;
+  }
   //変えたい場所（SignInコンポーネント）にニックネームに文字が入力されたらsetNameを利用して、nameの状態を変える。
   //setNameが更新されると、８行目のnameが更新される。すると、９行目のconsole.logでnameの内容がブラウザに表示される。
   return <SignIn setName={setName} />;

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Main = () => {
+  return <div>Main</div>
+};
+
+export default Main;

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -7,6 +7,7 @@ import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
+import { TextureRounded } from '@material-ui/icons';
 
 function Copyright() {
   return (
@@ -49,7 +50,9 @@ export default function SignIn({ setName }) {
   const [disabled, setDisabled] = useState(true);
   //ニックネームの文字列の状態をコンポーネントで管理して、その文字列があれば（空じゃなければ）有効、無ければ無効にする。
   const [string, setString] = useState('');
-  console.log({disabled, string});
+  //ニックネーム入力時、変更中（日本語管理中）という状態を管理（編集中だと認識された場合は、setNameが実行されないようにする処理）
+  const [isComposed, setIsComposed] = useState(false);
+
 
   useEffect(() => {
     //stringが空かどうか？をdisabledという変数に代入
@@ -80,12 +83,19 @@ export default function SignIn({ setName }) {
             onChange={(e) => setString(e.target.value)}
             //キーボードの入力を検知する処理
             onKeyDown={(e) => {
+              // isComposedがtrueだった場合は、以下記述している処理を行わないようにする処理。
+              if (isComposed) return;
               //oreventDefaultで画面全体がリロードしなくなる。
               if( e.key === 'Enter') {
                 setName(e.target.value);
                 e.preventDefault();
               }
             }}
+            //日本語変換(composition)についての処理
+            //日本語入力が始まったとわかった場合はsetIsComposedにtrueを設定する処理
+            onCompositionStart={() => setIsComposed(true)}
+            //日本語入力が終わったらsetIsComposedで初期状態（false)に設定する処理
+            onCompositionEnd={() =>setIsComposed(false)}
           />
           <Button
             type="button"


### PR DESCRIPTION
# What
Mainコンポーネントを作成
・nameの状態を管理（空だったらSignInコンポーネントを表示、空ではないならばMainコンポーネントを表示させる処理を実装）
・SignInコンポーネントが編集中かどうかを判断
（onKeyDownイベントを入力し、行いたい処理を記述。さらにonkeyDownイベント自体を行うか、行わないかの分岐処理を記載。
（if (isComposed) returnの部分）