### PR TITLE
input-field-grid

### DIFF
--- a/src/components/MessageInputField.js
+++ b/src/components/MessageInputField.js
@@ -1,15 +1,27 @@
 import React from 'react';
-import {makeStyles} from '@material-ui/core/styles';
+import { Avatar,Grid } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles({
   root: {
     gridRow: 2,
+    margin: '26px'
   },
 });
 
 const MessageInputField = () => {
   const classes = useStyles();
-  return <div className={classes.root}>MessageInputField</div>;
+  return (
+    <div className={classes.root}>
+      <Grid container>
+        <Grid xs={1}>
+          <Avatar />
+        </Grid>
+        <Grid xs={10}>入力</Grid>
+        <Grid xs={1}>ボタン</Grid>
+      </Grid>
+    </div>
+  );
 };
 
 export default MessageInputField;


### PR DESCRIPTION
# what
MessageFieldComponentにアバターとgridをmaterial-uiからインポート
<grid container>を設け、１２分割に分ける。