### PR TITLE
adjust-focusing

### DIFF
--- a/src/components/MessageField.js
+++ b/src/components/MessageField.js
@@ -4,12 +4,15 @@ import { TextField } from '@material-ui/core';
 
 import { pushMessage } from '../firebase';
 
-// MessageFieldにはname,setText,textが渡ってくる。
-const MessageField = ({ name, setText, text }) => {
+// MessageFieldにはname,setText,textが渡ってくる。inputElも渡す
+const MessageField = ({ inputEl, name, setText, text }) => {
   const [isComposed, setIsComposed] = useState(false);
   return (
     <TextField 
+      autoFocus
       fullWidth={true} 
+      //material-uiのtext-field APIのドキュメントを確認し、refを渡す場合はinputRefを使う必要があることがわかるので、次のように記載する。
+      inputRef={inputEl}
       // 状態を管理する記述。
       onChange={(e) => setText(e.target.value)}
       onKeyDown={(e) => {

--- a/src/components/MessageInputField.js
+++ b/src/components/MessageInputField.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Avatar,Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
@@ -15,6 +15,8 @@ const useStyles = makeStyles({
 });
 
 const MessageInputField = ({ name }) => {
+  // inputField全体にrefを定義する※公式doc参照
+  const inputEl = useRef(null);
   // text欄に入力したものをfirebaseに飛ばす際に、①ENTERキー押 or ②送信ボタンの２種類があるので、この２つが共通するコンポーネントの配下で状態管理する処理
   const [text, setText] = useState('');
   const classes = useStyles();
@@ -27,11 +29,22 @@ const MessageInputField = ({ name }) => {
           <Avatar src={avatarPath} />
         </Grid>
         <Grid item xs={10}>
-          <MessageField name={name} setText={setText} text={text} />
+          <MessageField
+            // 
+            inputEl={inputEl} 
+            name={name} 
+            setText={setText} 
+            text={text} 
+          />
         </Grid>
         <Grid item xs={1}>
           
-          <MessageSubmitButton name={name} setText={setText} text={text} />
+          <MessageSubmitButton
+            inputEl={inputEl}
+            name={name}
+            setText={setText} 
+            text={text} 
+          />
         </Grid>
       </Grid>
     </div>

--- a/src/components/MessageSubmitButton.js
+++ b/src/components/MessageSubmitButton.js
@@ -4,15 +4,19 @@ import SendIcon from '@material-ui/icons/Send';
 
 import { pushMessage } from '../firebase';
 //name, setText, textを受けとる。
-const MessageSubmitButton = ({ name, setText, text }) => {
+const MessageSubmitButton = ({ inputEl, name, setText, text }) => {
   return (
     // textの状態が空だったらtrueになる。disabledにtrueを設定すれば、「disabledできない」という状態になる。
     //クリックをした時にfirebaseに登録を行いたいので、onClickメソッドを使う必要がある。（onClickにはコールバック関数が使える）
-    <IconButton disabled={text === ''} onClick={() => {
+    <IconButton 
+      disabled={text === ''} 
+      onClick={() => {
       // firebaseへの登録はpushMessage関数で行うことができるので、name, textを渡す。
       pushMessage({ name: 'はむさん', text });
       // textの初期化（空文字を渡す）処理。
       setText('');
+      // 以下を実行することでfirebase登録後、自動でinput欄にフォーカスが当たるようになる。
+      inputEl.current.focus();
     }}>
       <SendIcon />
     </IconButton>


### PR DESCRIPTION
# What
useRefを使って、inputEl（inputタグに対するrefに設定するオブジェクト）を作成。
それをMessageFieldとMessageSubmitButtonの両方で使うようにした。
MessageFieldでは、inputElをinputRefで与えることで、<TextField>タグはinputフィールドのwrapperなので、inputのref属性に渡してくれている。

