### PR TITLE
display-messages

### DIFF
--- a/src/components/MessageItem.js
+++ b/src/components/MessageItem.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { 
+  Avatar, 
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+import { gravatarPath } from '../gravatar';
+
+const useStyles = makeStyles((theme) => ({
+  inline: {
+    display: 'inline',
+  },
+}));
+
+const MessageItem = ({ name, text }) => {
+  const classes = useStyles();
+  // gravatarPathにnameを渡して、avatarPath(これはURLに当たる)を生成する。
+  const avatarPath = gravatarPath(name);
+
+  return (
+    <ListItem divider={true}>
+      <ListItemAvatar>
+        <Avatar src={avatarPath} />
+      </ListItemAvatar>
+      <ListItemText
+        primary={name}
+        secondary={
+          <Typography
+            component="span"
+            variant="body2"
+            className={classes.inline}
+            color="textPrimary"
+          >
+            {text}
+          </Typography>
+        }
+      />
+    </ListItem>
+  );
+};
+
+export default MessageItem;

--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -1,11 +1,15 @@
 import React, { useEffect, useState } from 'react';
+import { List } from '@material-ui/core';
 import {makeStyles} from '@material-ui/core/styles';
 
+import MessageItem from './MessageItem';
 import { messagesRef } from '../firebase';
 
 const useStyles = makeStyles({
   root: {
     gridRow: 1,
+    overflow: 'auto',
+    width: '100%',
   },
 });
 
@@ -23,7 +27,7 @@ const MessageList = () => {
     // orderByKey()と記述することで時系列に表示できるように設定。公式docデータのクエリを参照。
     .orderByKey()
     // LimitToLast()と記述することで、直近のデータの取得数を指定できる。今回は直近の３件を取得する設定をしている。
-    .limitToLast(3)
+    .limitToLast(15)
     .on('value', (snapshot) => {
     // messagesという変数にsnapshot.val();というオブジェクトを代入する。
     const messages = snapshot.val();
@@ -46,7 +50,15 @@ const MessageList = () => {
     });
   }, []);
 
-  return <div className={classes.root}>MessageList</div>;
+  return ( 
+    // messageをループさせて、messageを個々で出力させる処理。
+    <List className={classes.root}>
+      {messages.map(({ key, name, text }) => {
+        //メッセージごとに個々のユニークなkeyをつけないとエラーが出るので、keyを指定する。加えて、MessageItemコンポーネントにnameとTextを渡す必要があるので、それらも追記する。
+        return <MessageItem key={key} name={name} text={text} >item</MessageItem>;
+      })}
+    </List>
+  );
 };
 
 export default MessageList;


### PR DESCRIPTION
# What
MessageItemコンポーネントを作成し、アイテム（１つの投稿）１個ぶんを出力する実装を行う。

material-uiのexampleをコピーして作成。

MessageList.jsでmessagesを管理して、１件ずつMessageItemコンポーネントを呼び出している。呼び出す際に、ユニークなkeyがないと警告が出るため、keyを付与。nameとtextも付与している。
